### PR TITLE
feat: add subtitle support for embedded video tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saltplayer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Minimalist torrent player with progressive streaming",
   "main": "dist/main/main.js",
   "author": "Konstantin Rerikh <knrerikh@gmail.com>",

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { IPC_CHANNELS, TorrentStatus, TorrentMetadata, ErrorInfo } from '@/shared/types';
+import { IPC_CHANNELS, TorrentStatus, TorrentMetadata, ErrorInfo, SubtitleData } from '@/shared/types';
 
 // Expose safe API to renderer process
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -28,6 +28,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onVideoMetadata: (callback: (metadata: { duration: number }) => void) => {
     ipcRenderer.on(IPC_CHANNELS.VIDEO_METADATA, (_, metadata) => callback(metadata));
   },
+  onSubtitles: (callback: (data: SubtitleData) => void) => {
+    ipcRenderer.on(IPC_CHANNELS.SUBTITLES, (_, data) => callback(data));
+  },
   onError: (callback: (error: ErrorInfo) => void) => {
     ipcRenderer.on(IPC_CHANNELS.ERROR, (_, error) => callback(error));
   },
@@ -52,6 +55,7 @@ declare global {
       onTorrentStatus: (callback: (status: TorrentStatus) => void) => void;
       onVideoUrl: (callback: (url: string) => void) => void;
       onVideoMetadata: (callback: (metadata: { duration: number }) => void) => void;
+      onSubtitles: (callback: (data: SubtitleData) => void) => void;
       onError: (callback: (error: ErrorInfo) => void) => void;
       removeAllListeners: (channel: string) => void;
     };

--- a/src/main/torrent.ts
+++ b/src/main/torrent.ts
@@ -1,4 +1,4 @@
-import { TorrentFile, TorrentMetadata, TorrentStatus, IPC_CHANNELS } from '@/shared/types';
+import { TorrentFile, TorrentMetadata, TorrentStatus, IPC_CHANNELS, SubtitleTrack } from '@/shared/types';
 import { StorageManager } from './storage';
 import { BrowserWindow } from 'electron';
 import * as http from 'http';
@@ -29,6 +29,7 @@ export class TorrentEngine {
   private server: any = null;
   private serverPort: number | null = null;
   private statusInterval: NodeJS.Timeout | null = null;
+  private subtitleTracks: SubtitleTrack[] = [];
 
   constructor(storageManager: StorageManager) {
     this.storageManager = storageManager;
@@ -226,25 +227,22 @@ export class TorrentEngine {
       const command = ffmpeg(streamUrl);
       let isResolved = false;
       
-      // Add timeout to prevent hanging forever
       const timeoutId = setTimeout(() => {
         console.warn('FFprobe timed out, proceeding with fallback check');
         isResolved = true;
         
-        // Fallback: If timeout, assume transcode needed for containers likely to have unsupported audio (MKV, AVI)
         const ext = streamUrl.split('?')[0].split('.').pop()?.toLowerCase();
         const unsafeExtensions = ['mkv', 'avi', 'wmv', 'flv', 'mov'];
         const fallbackTranscode = unsafeExtensions.includes(ext || '');
         
         resolve({ needsTranscode: fallbackTranscode, duration: 0 });
         
-        // Don't kill immediately, let it try to finish to get duration later
         setTimeout(() => {
             try {
                 command.kill('SIGKILL');
             } catch (e) {}
-        }, 60000); // Hard kill after 60s
-      }, 10000); // 10 seconds timeout for server start
+        }, 60000);
+      }, 10000);
 
       command.ffprobe((err, metadata) => {
         clearTimeout(timeoutId);
@@ -259,7 +257,6 @@ export class TorrentEngine {
         
         const duration = metadata.format?.duration ? Number(metadata.format.duration) : 0;
         
-        // If we resolved early (timeout), we still want to send the duration now that we have it
         if (isResolved && duration > 0) {
             this.sendVideoMetadata(duration);
         }
@@ -281,6 +278,54 @@ export class TorrentEngine {
     });
   }
 
+  private async extractSubtitles(streamUrl: string): Promise<void> {
+    return new Promise((resolve) => {
+      this.subtitleTracks = [];
+      
+      const command = ffmpeg(streamUrl);
+      
+      const timeoutId = setTimeout(() => {
+        console.warn('Subtitle extraction timed out');
+        command.kill('SIGKILL');
+        resolve();
+      }, 15000);
+
+      command.ffprobe((err, metadata) => {
+        clearTimeout(timeoutId);
+        
+        if (err) {
+          console.error('FFprobe subtitle error:', err.message);
+          resolve();
+          return;
+        }
+        
+        const subtitleStreams = metadata.streams.filter(s => s.codec_type === 'subtitle');
+        
+        if (subtitleStreams.length === 0) {
+          console.log('No embedded subtitles found');
+          this.sendSubtitles([]);
+          resolve();
+          return;
+        }
+
+        console.log(`Found ${subtitleStreams.length} subtitle track(s)`);
+        
+        subtitleStreams.forEach((stream, index) => {
+          const track: SubtitleTrack = {
+            index: stream.index,
+            language: stream.tags?.language || 'und',
+            title: stream.tags?.title || `Track ${index + 1}`,
+            url: `http://127.0.0.1:${this.serverPort}/subtitle/${stream.index}.vtt`
+          };
+          this.subtitleTracks.push(track);
+        });
+
+        this.sendSubtitles(this.subtitleTracks);
+        resolve();
+      });
+    });
+  }
+
   /**
    * Start HTTP streaming server
    */
@@ -298,6 +343,13 @@ export class TorrentEngine {
         const reqUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
         const isTranscode = reqUrl.searchParams.get('transcode') === 'true';
         const startTime = Number(reqUrl.searchParams.get('startTime') || '0');
+
+        const subtitleMatch = reqUrl.pathname.match(/^\/subtitle\/(\d+)\.vtt$/);
+        if (subtitleMatch) {
+          const streamIndex = parseInt(subtitleMatch[1], 10);
+          await this.serveSubtitle(streamIndex, res, file);
+          return;
+        }
 
         if (reqUrl.pathname !== pathname) {
           res.statusCode = 404;
@@ -444,8 +496,10 @@ export class TorrentEngine {
         this.sendVideoMetadata(probeResult.duration);
       }
 
+      this.extractSubtitles(streamUrl);
+
       if (probeResult.needsTranscode) {
-        console.log('⚠️ Transcoding enabled due to unsupported audio codec');
+        console.log('Transcoding enabled due to unsupported audio codec');
         streamUrl += '?transcode=true';
       }
 
@@ -458,11 +512,42 @@ export class TorrentEngine {
     const lower = filename.toLowerCase();
     if (lower.endsWith('.mp4') || lower.endsWith('.m4v')) return 'video/mp4';
     if (lower.endsWith('.webm')) return 'video/webm';
-    // Use video/x-matroska for MKV to let Chromium properly detect codecs
     if (lower.endsWith('.mkv')) return 'video/x-matroska';
     if (lower.endsWith('.avi')) return 'video/x-msvideo';
     if (lower.endsWith('.mov')) return 'video/quicktime';
     return 'application/octet-stream';
+  }
+
+  private async serveSubtitle(streamIndex: number, res: http.ServerResponse, file: any): Promise<void> {
+    const rawFileUrl = `http://127.0.0.1:${this.serverPort}/${encodeURIComponent(file.name)}`;
+    
+    res.writeHead(200, {
+      'Content-Type': 'text/vtt; charset=utf-8',
+      'Cache-Control': 'no-cache',
+    });
+
+    const command = ffmpeg(rawFileUrl)
+      .outputOptions([`-map 0:${streamIndex}`])
+      .format('webvtt');
+
+    const out = new PassThrough();
+
+    res.once('close', () => {
+      try {
+        command.kill('SIGKILL');
+      } catch {}
+    });
+
+    command.on('error', (err) => {
+      console.error('Subtitle extraction error:', err.message);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.end('Subtitle extraction failed');
+      }
+    });
+
+    command.pipe(out, { end: true });
+    pipeline(out, res, () => {});
   }
 
   /**
@@ -676,6 +761,13 @@ export class TorrentEngine {
     const windows = BrowserWindow.getAllWindows();
     windows.forEach(window => {
       window.webContents.send(IPC_CHANNELS.VIDEO_METADATA, { duration });
+    });
+  }
+
+  private sendSubtitles(tracks: SubtitleTrack[]): void {
+    const windows = BrowserWindow.getAllWindows();
+    windows.forEach(window => {
+      window.webContents.send(IPC_CHANNELS.SUBTITLES, { tracks, hasEmbeddedSubtitles: tracks.length > 0 });
     });
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import TorrentInput from './components/TorrentInput';
 import VideoPlayer from './components/VideoPlayer';
 import StatusBar from './components/StatusBar';
-import { TorrentStatus, TorrentMetadata, ErrorInfo, TorrentFile } from '@/shared/types';
+import { TorrentStatus, TorrentMetadata, ErrorInfo, TorrentFile, SubtitleData } from '@/shared/types';
 
 const VIDEO_EXTENSIONS = ['.mp4', '.mkv', '.avi', '.mov', '.webm', '.m4v', '.flv', '.wmv'];
 
@@ -20,6 +20,7 @@ declare global {
       onTorrentStatus: (callback: (status: TorrentStatus) => void) => void;
       onVideoUrl: (callback: (url: string) => void) => void;
       onVideoMetadata: (callback: (metadata: { duration: number }) => void) => void;
+      onSubtitles: (callback: (data: SubtitleData) => void) => void;
       onError: (callback: (error: ErrorInfo) => void) => void;
       removeAllListeners: (channel: string) => void;
     };
@@ -33,6 +34,7 @@ const App: React.FC = () => {
   const [metadata, setMetadata] = useState<TorrentMetadata | null>(null);
   const [error, setError] = useState<ErrorInfo | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [subtitleData, setSubtitleData] = useState<SubtitleData | null>(null);
 
   useEffect(() => {
     // Set application title
@@ -50,8 +52,12 @@ const App: React.FC = () => {
       console.log('Received video metadata:', meta);
       setServerDuration(meta.duration);
     });
+
+    window.electronAPI.onSubtitles((data) => {
+      console.log('Received subtitles:', data);
+      setSubtitleData(data);
+    });
     
-    // Listen for torrent status updates
     window.electronAPI.onTorrentStatus((status) => {
       setTorrentStatus(status);
     });
@@ -64,9 +70,9 @@ const App: React.FC = () => {
     });
 
     return () => {
-      // Cleanup listeners
       window.electronAPI.removeAllListeners('video:url');
       window.electronAPI.removeAllListeners('video:metadata');
+      window.electronAPI.removeAllListeners('subtitles:available');
       window.electronAPI.removeAllListeners('torrent:status');
       window.electronAPI.removeAllListeners('error');
     };
@@ -96,7 +102,8 @@ const App: React.FC = () => {
       setTorrentStatus(null);
       setMetadata(null);
       setIsLoading(false);
-    } catch (err) {
+      setSubtitleData(null);
+    } catch (err: any) {
       console.error('Error stopping torrent:', err);
     }
   };
@@ -187,6 +194,7 @@ const App: React.FC = () => {
         title={currentIndex !== -1 ? videoFiles[currentIndex].name : undefined}
         videoFiles={videoFiles}
         onSelectFile={handleSelectFile}
+        subtitleData={subtitleData}
       />
       
       <StatusBar  

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -1,16 +1,18 @@
 import React, { useRef, useState, useEffect, useMemo, useCallback } from 'react';
+import { SubtitleData } from '@/shared/types';
 
 interface VideoPlayerProps {
   videoUrl: string | null;
   serverDuration?: number | null;
   isLoading: boolean;
-  isBuffering: boolean; // We'll ignore this prop mostly, relying on native events
+  isBuffering: boolean;
   onClose?: () => void;
   onPrev?: () => void;
   onNext?: () => void;
   title?: string;
   videoFiles?: { name: string }[];
   onSelectFile?: (fileName: string) => void;
+  subtitleData?: SubtitleData | null;
 }
 
 const VideoPlayer: React.FC<VideoPlayerProps> = ({ 
@@ -22,7 +24,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   onNext,
   title,
   videoFiles,
-  onSelectFile
+  onSelectFile,
+  subtitleData
   }) => {
     const videoRef = useRef<HTMLVideoElement>(null);
     const [isPlaying, setIsPlaying] = useState(false);
@@ -34,6 +37,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const [isBuffering, setIsBuffering] = useState(false);
   const [timeOffset, setTimeOffset] = useState(0);
   const [overlayIcon, setOverlayIcon] = useState<'play' | 'pause' | null>(null);
+  const [subtitlesEnabled, setSubtitlesEnabled] = useState(false);
+  const [currentSubtitleIndex, setCurrentSubtitleIndex] = useState(0);
 
   const isTranscode = useMemo(() => {
     return videoUrl?.includes('transcode=true') || false;
@@ -42,6 +47,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   // Reset time offset when video URL changes (new file)
   useEffect(() => {
     setTimeOffset(0);
+    setSubtitlesEnabled(false);
   }, [videoUrl]);
 
   useEffect(() => {
@@ -268,7 +274,16 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
             autoPlay
             controls={false}
             onClick={togglePlay}
-          />
+          >
+            {subtitleData?.tracks && subtitleData.tracks.length > 0 && subtitlesEnabled && (
+              <track
+                kind="subtitles"
+                src={subtitleData.tracks[currentSubtitleIndex]?.url}
+                srcLang={subtitleData.tracks[currentSubtitleIndex]?.language}
+                default
+              />
+            )}
+          </video>
           
           {onClose && (
             <button className="close-button" onClick={onClose} title="Close">
@@ -382,6 +397,17 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                 value={volume}
                 onChange={handleVolumeChange}
               />
+              
+              {subtitleData?.hasEmbeddedSubtitles && (
+                <button 
+                  className="control-button" 
+                  onClick={() => setSubtitlesEnabled(!subtitlesEnabled)}
+                  title={subtitlesEnabled ? 'Disable subtitles' : 'Enable subtitles'}
+                  style={{ opacity: subtitlesEnabled ? 1 : 0.5 }}
+                >
+                  CC
+                </button>
+              )}
               
               <button className="control-button" onClick={toggleFullscreen}>
                 {isFullscreen ? '⊗' : '⛶'}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,7 +52,20 @@ export const IPC_CHANNELS = {
   VIDEO_URL: 'video:url',
   TORRENT_SELECT_FILE: 'torrent:selectFile',
   VIDEO_METADATA: 'video:metadata',
+  SUBTITLES: 'subtitles:available',
 } as const;
 
 export type PlaybackControlAction = 'play' | 'pause' | 'stop';
+
+export interface SubtitleTrack {
+  index: number;
+  language: string;
+  title?: string;
+  url: string;
+}
+
+export interface SubtitleData {
+  tracks: SubtitleTrack[];
+  hasEmbeddedSubtitles: boolean;
+}
 

--- a/tests/integration/videoplayer.test.tsx
+++ b/tests/integration/videoplayer.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import VideoPlayer from '@/renderer/components/VideoPlayer';
+import { SubtitleData } from '@/shared/types';
 
 describe('VideoPlayer Component', () => {
   beforeEach(() => {
@@ -322,6 +323,175 @@ describe('VideoPlayer Component', () => {
       );
 
       expect(video.src).toContain('video2.mp4');
+    });
+  });
+
+  describe('Subtitles', () => {
+    const mockSubtitleData: SubtitleData = {
+      tracks: [
+        { index: 0, language: 'eng', title: 'English', url: 'http://localhost:8080/subtitle/0.vtt' },
+        { index: 1, language: 'rus', title: 'Russian', url: 'http://localhost:8080/subtitle/1.vtt' }
+      ],
+      hasEmbeddedSubtitles: true
+    };
+
+    it('should show CC button when subtitles are available', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
+        btn => btn.textContent === 'CC'
+      );
+      expect(ccButton).toBeTruthy();
+    });
+
+    it('should not show CC button when no subtitles available', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={{ tracks: [], hasEmbeddedSubtitles: false }}
+        />
+      );
+
+      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
+        btn => btn.textContent === 'CC'
+      );
+      expect(ccButton).toBeFalsy();
+    });
+
+    it('should not show CC button when subtitleData is null', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={null}
+        />
+      );
+
+      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
+        btn => btn.textContent === 'CC'
+      );
+      expect(ccButton).toBeFalsy();
+    });
+
+    it('should have subtitles disabled by default', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
+        btn => btn.textContent === 'CC'
+      ) as HTMLButtonElement;
+
+      expect(ccButton.style.opacity).toBe('0.5');
+    });
+
+    it('should toggle subtitles when CC button is clicked', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
+        btn => btn.textContent === 'CC'
+      ) as HTMLButtonElement;
+
+      expect(ccButton.style.opacity).toBe('0.5');
+
+      fireEvent.click(ccButton);
+
+      expect(ccButton.style.opacity).toBe('1');
+
+      fireEvent.click(ccButton);
+
+      expect(ccButton.style.opacity).toBe('0.5');
+    });
+
+    it('should render track element when subtitles are enabled', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
+        btn => btn.textContent === 'CC'
+      ) as HTMLButtonElement;
+
+      fireEvent.click(ccButton);
+
+      const track = container.querySelector('track');
+      expect(track).toBeTruthy();
+      expect(track?.getAttribute('src')).toBe('http://localhost:8080/subtitle/0.vtt');
+      expect(track?.getAttribute('kind')).toBe('subtitles');
+    });
+
+    it('should not render track element when subtitles are disabled', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const track = container.querySelector('track');
+      expect(track).toBeFalsy();
+    });
+
+    it('should reset subtitles when video URL changes', () => {
+      const { container, rerender } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video1.mp4"
+          title="Video 1"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
+        btn => btn.textContent === 'CC'
+      ) as HTMLButtonElement;
+
+      fireEvent.click(ccButton);
+      expect(ccButton.style.opacity).toBe('1');
+
+      rerender(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video2.mp4"
+          title="Video 2"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const ccButtonAfter = Array.from(container.querySelectorAll('.control-button')).find(
+        btn => btn.textContent === 'CC'
+      ) as HTMLButtonElement;
+
+      expect(ccButtonAfter.style.opacity).toBe('0.5');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add detection and extraction of embedded subtitles from video files using ffprobe
- Serve subtitles via HTTP endpoint in WebVTT format using ffmpeg
- Add CC toggle button in video player controls (subtitles disabled by default)
- Add IPC channel for subtitle data transfer between main and renderer processes
- Add comprehensive tests for subtitle functionality (8 new tests)
- Bump version to 1.2.0

## Changes
- `src/shared/types.ts`: Added `SubtitleTrack`, `SubtitleData` types and `SUBTITLES` IPC channel
- `src/main/torrent.ts`: Added subtitle extraction via ffprobe and HTTP serving via ffmpeg
- `src/main/preload.ts`: Added `onSubtitles` API for renderer
- `src/renderer/App.tsx`: Added subtitle state management and listener
- `src/renderer/components/VideoPlayer.tsx`: Added CC button and subtitle track rendering
- `tests/integration/videoplayer.test.tsx`: Added 8 tests for subtitle functionality

## Test plan
- [x] Unit tests pass (64 tests)
- [x] Integration tests pass (57 tests)
- [x] Build succeeds for macOS
- [x] Manual testing with video files containing embedded subtitles