### PR TITLE
feat: add subtitle language selection menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db
 # IDE
 .vscode/
 .idea/
+.cursor/
 *.swp
 *.swo
 *~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saltplayer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Minimalist torrent player with progressive streaming",
   "main": "dist/main/main.js",
   "author": "Konstantin Rerikh <knrerikh@gmail.com>",

--- a/src/main/torrent.ts
+++ b/src/main/torrent.ts
@@ -20,6 +20,14 @@ let WebTorrentClass: any = null;
 
 const VIDEO_EXTENSIONS = ['.mp4', '.mkv', '.avi', '.mov', '.webm', '.m4v', '.flv', '.wmv'];
 
+/** Extract ISO 639-2 language code from values like "rus-sub", "eng-forced" */
+function normalizeSubtitleLanguage(raw: string): string {
+  const s = (raw || 'und').trim().toLowerCase();
+  if (!s || s === 'und') return 'und';
+  const match = s.match(/^([a-z]{2,3})(?:[-_].*)?$/);
+  return match ? match[1] : s;
+}
+
 export class TorrentEngine {
   private client: any | null = null;
   private currentTorrent: any | null = null;
@@ -311,10 +319,13 @@ export class TorrentEngine {
         console.log(`Found ${subtitleStreams.length} subtitle track(s)`);
         
         subtitleStreams.forEach((stream, index) => {
+          const streamAny = stream as { tags?: { language?: string; title?: string; LANGUAGE?: string }; language?: string };
+          const rawLang = streamAny.tags?.language ?? streamAny.tags?.LANGUAGE ?? streamAny.language ?? 'und';
+          const lang = normalizeSubtitleLanguage(typeof rawLang === 'string' ? rawLang : 'und');
           const track: SubtitleTrack = {
             index: stream.index,
-            language: stream.tags?.language || 'und',
-            title: stream.tags?.title || `Track ${index + 1}`,
+            language: lang,
+            title: streamAny.tags?.title ?? `Track ${index + 1}`,
             url: `http://127.0.0.1:${this.serverPort}/subtitle/${stream.index}.vtt`
           };
           this.subtitleTracks.push(track);

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -1,5 +1,42 @@
 import React, { useRef, useState, useEffect, useMemo, useCallback } from 'react';
-import { SubtitleData } from '@/shared/types';
+import { SubtitleData, SubtitleTrack } from '@/shared/types';
+
+// ISO 639-2 language codes → human-readable names (for subtitle menu)
+const SUBTITLE_LANGUAGE_NAMES: Record<string, string> = {
+  eng: 'English', rus: 'Russian', spa: 'Spanish', fra: 'French', deu: 'German',
+  ita: 'Italian', por: 'Portuguese', jpn: 'Japanese', kor: 'Korean', zho: 'Chinese',
+  ara: 'Arabic', hin: 'Hindi', tur: 'Turkish', pol: 'Polish', ukr: 'Ukrainian',
+  swe: 'Swedish', nld: 'Dutch', dan: 'Danish', nor: 'Norwegian', fin: 'Finnish',
+  ell: 'Greek', heb: 'Hebrew', tha: 'Thai', vie: 'Vietnamese', ind: 'Indonesian',
+  und: 'Unknown',
+};
+
+const TECHNICAL_TITLES = new Set(['sdh', 'forced', 'default', 'full', 'cc']);
+const TECHNICAL_TITLE_PATTERN = /^[a-z]{2,3}-[a-z0-9]+$/i;
+
+function normalizeLanguageForDisplay(raw: string): string {
+  const s = (raw || '').trim().toLowerCase();
+  const m = s.match(/^([a-z]{2,3})(?:[-_].*)?$/);
+  return m ? m[1] : s;
+}
+
+function getSubtitleDisplayName(track: SubtitleTrack): string {
+  const t = (track.title || '').trim();
+  let lang = normalizeLanguageForDisplay(track.language);
+  if (lang === 'und' && t && TECHNICAL_TITLE_PATTERN.test(t)) {
+    const extracted = t.match(/^([a-z]{2,3})-/i);
+    if (extracted) lang = extracted[1].toLowerCase();
+  }
+  const langName = SUBTITLE_LANGUAGE_NAMES[lang] || SUBTITLE_LANGUAGE_NAMES[track.language] || 'Unknown';
+  const isGenericTitle = !t || /^Track\s+\d+$/i.test(t) || /^\d+$/.test(t);
+  const isTechnicalCode = TECHNICAL_TITLE_PATTERN.test(t);
+  const isTechnicalDescriptor = TECHNICAL_TITLES.has(t.toLowerCase());
+  if (t && !isGenericTitle && !isTechnicalCode) {
+    if (isTechnicalDescriptor) return `${langName} (${t})`;
+    return track.title!;
+  }
+  return langName;
+}
 
 interface VideoPlayerProps {
   videoUrl: string | null;
@@ -39,16 +76,46 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const [overlayIcon, setOverlayIcon] = useState<'play' | 'pause' | null>(null);
   const [subtitlesEnabled, setSubtitlesEnabled] = useState(false);
   const [currentSubtitleIndex, setCurrentSubtitleIndex] = useState(0);
+  const [subtitleMenuOpen, setSubtitleMenuOpen] = useState(false);
+  const subtitleControlRef = useRef<HTMLDivElement>(null);
 
   const isTranscode = useMemo(() => {
     return videoUrl?.includes('transcode=true') || false;
   }, [videoUrl]);
 
-  // Reset time offset when video URL changes (new file)
+  // Reset time offset and subtitle index when video URL changes (new file)
   useEffect(() => {
     setTimeOffset(0);
     setSubtitlesEnabled(false);
+    setCurrentSubtitleIndex(0);
   }, [videoUrl]);
+
+  // Keep currentSubtitleIndex in bounds when tracks change
+  useEffect(() => {
+    const tracks = subtitleData?.tracks;
+    if (tracks && tracks.length > 0 && currentSubtitleIndex >= tracks.length) {
+      setCurrentSubtitleIndex(0);
+    }
+  }, [subtitleData?.tracks, currentSubtitleIndex]);
+
+  // Close subtitle menu on outside click or Escape
+  useEffect(() => {
+    if (!subtitleMenuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (subtitleControlRef.current && !subtitleControlRef.current.contains(e.target as Node)) {
+        setSubtitleMenuOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setSubtitleMenuOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [subtitleMenuOpen]);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -399,14 +466,53 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
               />
               
               {subtitleData?.hasEmbeddedSubtitles && (
-                <button 
-                  className="control-button" 
-                  onClick={() => setSubtitlesEnabled(!subtitlesEnabled)}
-                  title={subtitlesEnabled ? 'Disable subtitles' : 'Enable subtitles'}
-                  style={{ opacity: subtitlesEnabled ? 1 : 0.5 }}
-                >
-                  CC
-                </button>
+                <div className="subtitle-control" ref={subtitleControlRef}>
+                  <button
+                    type="button"
+                    className="subtitle-control-cc"
+                    onClick={() => setSubtitlesEnabled(!subtitlesEnabled)}
+                    title={subtitlesEnabled ? 'Disable subtitles' : 'Enable subtitles'}
+                    style={{ opacity: subtitlesEnabled ? 1 : 0.5 }}
+                  >
+                    CC
+                  </button>
+                  <button
+                    type="button"
+                    className="subtitle-control-arrow"
+                    onClick={(e) => { e.stopPropagation(); setSubtitleMenuOpen((open) => !open); }}
+                    title="Subtitle language"
+                    aria-expanded={subtitleMenuOpen}
+                  >
+                    ▼
+                  </button>
+                  {subtitleMenuOpen && subtitleData?.tracks && (
+                    <div className="subtitle-menu" role="menu">
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className="subtitle-menu-item"
+                        onClick={() => { setSubtitlesEnabled(false); setSubtitleMenuOpen(false); }}
+                      >
+                        Off
+                      </button>
+                      {subtitleData.tracks.map((track, index) => (
+                        <button
+                          key={track.index}
+                          type="button"
+                          role="menuitem"
+                          className="subtitle-menu-item"
+                          onClick={() => {
+                            setCurrentSubtitleIndex(index);
+                            setSubtitlesEnabled(true);
+                            setSubtitleMenuOpen(false);
+                          }}
+                        >
+                          {getSubtitleDisplayName(track)}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
               )}
               
               <button className="control-button" onClick={toggleFullscreen}>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -326,6 +326,79 @@ body {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
+/* Subtitle control: split button [ CC | ▼ ] + dropdown */
+.subtitle-control {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 36px;
+  border-radius: 50%;
+  overflow: visible;
+}
+
+.subtitle-control-cc,
+.subtitle-control-arrow {
+  height: 36px;
+  background-color: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s;
+  padding: 0;
+}
+
+.subtitle-control-cc {
+  width: 28px;
+  border-radius: 50% 0 0 50%;
+  font-size: 12px;
+}
+
+.subtitle-control-arrow {
+  width: 20px;
+  border-radius: 0 50% 50% 0;
+  font-size: 8px;
+  margin-left: -1px;
+}
+
+.subtitle-control-cc:hover,
+.subtitle-control-arrow:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.subtitle-menu {
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 4px;
+  background-color: rgba(0, 0, 0, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  padding: 4px 0;
+  min-width: 120px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.subtitle-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 14px;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.subtitle-menu-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
 .seek-bar {
   flex: 1;
   height: 6px;

--- a/tests/integration/videoplayer.test.tsx
+++ b/tests/integration/videoplayer.test.tsx
@@ -345,10 +345,24 @@ describe('VideoPlayer Component', () => {
         />
       );
 
-      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
-        btn => btn.textContent === 'CC'
-      );
+      const ccButton = container.querySelector('.subtitle-control-cc');
       expect(ccButton).toBeTruthy();
+      expect(ccButton?.textContent).toBe('CC');
+    });
+
+    it('should show arrow button when subtitles are available', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const arrowButton = container.querySelector('.subtitle-control-arrow');
+      expect(arrowButton).toBeTruthy();
+      expect(arrowButton?.textContent).toBe('▼');
     });
 
     it('should not show CC button when no subtitles available', () => {
@@ -361,10 +375,8 @@ describe('VideoPlayer Component', () => {
         />
       );
 
-      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
-        btn => btn.textContent === 'CC'
-      );
-      expect(ccButton).toBeFalsy();
+      const subtitleControl = container.querySelector('.subtitle-control');
+      expect(subtitleControl).toBeFalsy();
     });
 
     it('should not show CC button when subtitleData is null', () => {
@@ -377,10 +389,8 @@ describe('VideoPlayer Component', () => {
         />
       );
 
-      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
-        btn => btn.textContent === 'CC'
-      );
-      expect(ccButton).toBeFalsy();
+      const subtitleControl = container.querySelector('.subtitle-control');
+      expect(subtitleControl).toBeFalsy();
     });
 
     it('should have subtitles disabled by default', () => {
@@ -393,10 +403,7 @@ describe('VideoPlayer Component', () => {
         />
       );
 
-      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
-        btn => btn.textContent === 'CC'
-      ) as HTMLButtonElement;
-
+      const ccButton = container.querySelector('.subtitle-control-cc') as HTMLButtonElement;
       expect(ccButton.style.opacity).toBe('0.5');
     });
 
@@ -410,9 +417,7 @@ describe('VideoPlayer Component', () => {
         />
       );
 
-      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
-        btn => btn.textContent === 'CC'
-      ) as HTMLButtonElement;
+      const ccButton = container.querySelector('.subtitle-control-cc') as HTMLButtonElement;
 
       expect(ccButton.style.opacity).toBe('0.5');
 
@@ -435,9 +440,7 @@ describe('VideoPlayer Component', () => {
         />
       );
 
-      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
-        btn => btn.textContent === 'CC'
-      ) as HTMLButtonElement;
+      const ccButton = container.querySelector('.subtitle-control-cc') as HTMLButtonElement;
 
       fireEvent.click(ccButton);
 
@@ -461,6 +464,111 @@ describe('VideoPlayer Component', () => {
       expect(track).toBeFalsy();
     });
 
+    it('should open language menu when arrow is clicked', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const arrowButton = container.querySelector('.subtitle-control-arrow') as HTMLButtonElement;
+      expect(container.querySelector('.subtitle-menu')).toBeFalsy();
+
+      fireEvent.click(arrowButton);
+
+      const menu = container.querySelector('.subtitle-menu');
+      expect(menu).toBeTruthy();
+      const items = menu?.querySelectorAll('.subtitle-menu-item');
+      expect(items).toHaveLength(3); // Off + English + Russian
+      expect(items?.[0].textContent).toBe('Off');
+      expect(items?.[1].textContent).toBe('English');
+      expect(items?.[2].textContent).toBe('Russian');
+    });
+
+    it('should enable subtitles and set track when selecting language from menu', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const arrowButton = container.querySelector('.subtitle-control-arrow') as HTMLButtonElement;
+      fireEvent.click(arrowButton);
+
+      const menu = container.querySelector('.subtitle-menu');
+      const russianItem = Array.from(menu?.querySelectorAll('.subtitle-menu-item') ?? []).find(
+        el => el.textContent === 'Russian'
+      ) as HTMLButtonElement;
+      fireEvent.click(russianItem);
+
+      const track = container.querySelector('track');
+      expect(track).toBeTruthy();
+      expect(track?.getAttribute('src')).toBe('http://localhost:8080/subtitle/1.vtt');
+
+      const ccButton = container.querySelector('.subtitle-control-cc') as HTMLButtonElement;
+      expect(ccButton.style.opacity).toBe('1');
+    });
+
+    it('should disable subtitles and close menu when selecting Off', () => {
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      const ccButton = container.querySelector('.subtitle-control-cc') as HTMLButtonElement;
+      fireEvent.click(ccButton);
+      expect(ccButton.style.opacity).toBe('1');
+
+      const arrowButton = container.querySelector('.subtitle-control-arrow') as HTMLButtonElement;
+      fireEvent.click(arrowButton);
+
+      const menu = container.querySelector('.subtitle-menu');
+      const offItem = menu?.querySelector('.subtitle-menu-item') as HTMLButtonElement;
+      fireEvent.click(offItem);
+
+      expect(container.querySelector('.subtitle-menu')).toBeFalsy();
+      expect(ccButton.style.opacity).toBe('0.5');
+      expect(container.querySelector('track')).toBeFalsy();
+    });
+
+    it('should display human-readable language for technical codes (rus-sub, SDH)', () => {
+      const technicalSubtitleData: SubtitleData = {
+        tracks: [
+          { index: 0, language: 'rus-sub', title: 'rus-sub', url: 'http://localhost:8080/subtitle/0.vtt' },
+          { index: 1, language: 'eng', title: 'SDH', url: 'http://localhost:8080/subtitle/1.vtt' },
+          { index: 2, language: 'und', title: 'rus-sub', url: 'http://localhost:8080/subtitle/2.vtt' }
+        ],
+        hasEmbeddedSubtitles: true
+      };
+      const { container } = render(
+        <VideoPlayer 
+          videoUrl="http://localhost:8080/video.mp4"
+          title="Test Video"
+          onClose={vi.fn()}
+          subtitleData={technicalSubtitleData}
+        />
+      );
+
+      const arrowButton = container.querySelector('.subtitle-control-arrow') as HTMLButtonElement;
+      fireEvent.click(arrowButton);
+
+      const menu = container.querySelector('.subtitle-menu');
+      const items = menu?.querySelectorAll('.subtitle-menu-item');
+      expect(items?.[1].textContent).toBe('Russian');
+      expect(items?.[2].textContent).toBe('English (SDH)');
+      expect(items?.[3].textContent).toBe('Russian');
+    });
+
     it('should reset subtitles when video URL changes', () => {
       const { container, rerender } = render(
         <VideoPlayer 
@@ -471,9 +579,7 @@ describe('VideoPlayer Component', () => {
         />
       );
 
-      const ccButton = Array.from(container.querySelectorAll('.control-button')).find(
-        btn => btn.textContent === 'CC'
-      ) as HTMLButtonElement;
+      const ccButton = container.querySelector('.subtitle-control-cc') as HTMLButtonElement;
 
       fireEvent.click(ccButton);
       expect(ccButton.style.opacity).toBe('1');
@@ -487,9 +593,7 @@ describe('VideoPlayer Component', () => {
         />
       );
 
-      const ccButtonAfter = Array.from(container.querySelectorAll('.control-button')).find(
-        btn => btn.textContent === 'CC'
-      ) as HTMLButtonElement;
+      const ccButtonAfter = container.querySelector('.subtitle-control-cc') as HTMLButtonElement;
 
       expect(ccButtonAfter.style.opacity).toBe('0.5');
     });

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -35,6 +35,10 @@ module.exports = {
     'ffmpeg-static': 'commonjs ffmpeg-static',
     'ffprobe-static': 'commonjs ffprobe-static',
     'fluent-ffmpeg': 'commonjs fluent-ffmpeg',
-  }
+  },
+  ignoreWarnings: [
+    { module: /node_modules\/fs-native-extensions/ },
+    { module: /node_modules\/require-addon/ },
+  ],
 };
 

--- a/webpack.renderer.config.js
+++ b/webpack.renderer.config.js
@@ -44,7 +44,6 @@ module.exports = {
       Buffer: ['buffer', 'Buffer'],
     }),
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
       'global': 'globalThis',
     })
   ],


### PR DESCRIPTION
## Summary
- Added dropdown menu for selecting subtitle language tracks
- Fixed subtitle display to show human-readable language names (e.g., "Russian", "English") instead of technical codes (e.g., "rus-sub", "SDH")
- Bumped version to 1.3.0

## Changes
- **VideoPlayer.tsx**: New subtitle control with dropdown menu, language name mapping for ISO 639-2 codes
- **torrent.ts**: Improved subtitle language extraction with normalization
- **webpack configs**: Fixed build warnings

## Test plan
- [ ] Play video with embedded subtitles
- [ ] Verify subtitle menu shows language names correctly
- [ ] Switch between subtitle tracks
- [ ] Disable subtitles via "Off" option