### PR TITLE
feat: add audio track selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,80 +1,66 @@
-name: Tests
+name: Release
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    tags:
+      - 'v*'
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18.x, 20.x]
-    
+        node-version: [20.x]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run linter
         run: npm run lint --if-present
-      
+
       - name: Run unit tests
         run: npm run test:unit
-      
+
       - name: Run integration tests
         run: npm run test:integration
-      
-      - name: Generate coverage
-        run: npm run test:coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
-      
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
-        with:
-          files: ./coverage/coverage-final.json
-          flags: unittests
-          name: codecov-umbrella
 
-  build:
+  publish:
     needs: test
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Build application
         run: npm run build
-      
-      - name: Package application
-        run: npm run package
+
+      - name: Package and publish
+        run: npm run package -- --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,224 @@
+# AGENTS.md - Developer Guide for Salt Player
+
+## Build Commands
+
+```bash
+# Development
+npm run dev              # Start all dev processes (main + renderer + electron)
+npm run dev:main        # Watch main process
+npm run dev:renderer    # Watch renderer process
+
+# Build
+npm run build           # Build both main and renderer
+npm run build:main     # Build main process only
+npm run build:renderer # Build renderer only
+npm run start          # Run Electron app (requires build first)
+
+# Package (create distributables)
+npm run package                    # Build for current OS
+npm run package -- --mac          # macOS
+npm run package -- --win           # Windows
+npm run package -- --linux        # Linux
+npm run package -- --publish always # Publish to GitHub Releases
+```
+
+## Test Commands
+
+```bash
+npm test              # Run all tests (vitest)
+npm run test:unit     # Run unit tests only
+npm run test:integration  # Run integration tests only
+npm run test:coverage # Run tests with coverage
+npm run test:watch    # Watch mode for tests
+
+# Run single test file
+vitest run tests/unit/<filename>
+vitest run tests/integration/<filename>
+
+# Run single test
+vitest run -t "test name"
+```
+
+## Project Structure
+
+```
+src/
+├── main/              # Electron main process (Node.js)
+│   ├── main.ts       # App entry point
+│   ├── preload.ts    # Preload script (context bridge)
+│   ├── torrent.ts    # Torrent engine (WebTorrent + FFmpeg)
+│   ├── storage.ts    # Persistent storage
+│   └── ipc-handlers.ts
+├── renderer/          # Electron renderer process (browser)
+│   ├── App.tsx       # Root React component
+│   ├── index.tsx     # Entry point
+│   ├── components/   # React components
+│   └── styles.css
+└── shared/            # Shared types
+    └── types.ts
+```
+
+## Code Style Guidelines
+
+### Imports
+
+- Use path aliases: `@/` for shared types (`@/shared/types`)
+- Order: external libs → internal modules → relative paths
+- Named imports for React: `import { useState, useEffect } from 'react'`
+
+```typescript
+// Good
+import React, { useState, useEffect, useMemo } from 'react';
+import { TorrentStatus, SubtitleData } from '@/shared/types';
+import TorrentInput from './components/TorrentInput';
+
+// Avoid
+import * as React from 'react';
+import { * } from '@/shared/types';
+```
+
+### TypeScript
+
+- Use explicit types for function parameters and return types
+- Use interfaces for object shapes, types for unions/primitives
+- Avoid `any`, use `unknown` when type is truly unknown
+
+```typescript
+// Good
+interface VideoPlayerProps {
+  videoUrl: string | null;
+  onClose: () => void;
+}
+
+function getSubtitleDisplayName(track: SubtitleTrack): string {
+  // ...
+}
+
+// Avoid
+function handleSomething(data) {  // missing types
+  // ...
+}
+```
+
+### Naming Conventions
+
+- **Files**: kebab-case for configs, PascalCase for components, camelCase for utilities
+  - `video-player.tsx`, `ipc-handlers.ts`, `TorrentEngine.ts`
+- **Components**: PascalCase, `.tsx` extension
+- **Functions/variables**: camelCase
+- **Constants**: UPPER_SNAKE_CASE for config values, camelCase for others
+- **Interfaces**: PascalCase, descriptive names (`TorrentMetadata`, not `TM`)
+
+### React Patterns
+
+- Use Functional components with hooks
+- Destructure props in function signature
+- Keep components focused (single responsibility)
+- Use `useMemo` for expensive calculations
+- Use `useCallback` for functions passed as props
+- Add dependencies array to useEffect
+
+```typescript
+// Good
+const VideoPlayer: React.FC<VideoPlayerProps> = ({
+  videoUrl,
+  onClose,
+}) => {
+  const isPlaying = useMemo(() => {
+    return videoUrl?.includes('transcode=true') || false;
+  }, [videoUrl]);
+
+  const handlePlay = useCallback(() => {
+    // ...
+  }, [dependencies]);
+};
+
+// Cleanup effects
+useEffect(() => {
+  const subscription = something.onData(handler);
+  return () => subscription.off(handler);
+}, [dependencies]);
+```
+
+### Error Handling
+
+- Use try/catch for async operations
+- Log errors with context: `console.error('Error loading torrent:', err)`
+- Set error state in UI, show user-friendly messages
+- Never expose internal errors to end users
+
+```typescript
+// Good
+try {
+  const meta = await window.electronAPI.loadTorrent(source);
+  setMetadata(meta);
+} catch (err: unknown) {
+  console.error('Failed to load torrent:', err);
+  setError({
+    code: 'LOAD_ERROR',
+    message: err instanceof Error ? err.message : 'Unknown error',
+  });
+}
+```
+
+### CSS
+
+- Use CSS classes, not inline styles (except dynamic values)
+- Follow existing class naming in `styles.css`
+- Keep styles in `src/renderer/styles.css`
+
+### Electron Specific
+
+- Use contextBridge for IPC (never expose `ipcRenderer` directly)
+- Define API in Window interface (see `App.tsx`)
+- Use IPC_CHANNELS constants for channel names
+- Handle both development and production paths
+
+```typescript
+// In preload.ts
+contextBridge.exposeInMainWorld('electronAPI', {
+  loadTorrent: (source: string) => ipcRenderer.invoke('torrent:load', source),
+});
+```
+
+### Testing
+
+- Place tests in `tests/unit/` or `tests/integration/`
+- Name test files: `*.test.ts` or `*.test.tsx`
+- Use Vitest (already configured)
+- Use @testing-library/react for component tests
+
+### Git Conventions
+
+- Branch naming: `feature/description`, `fix/description`, `hotfix/description`
+- Commit messages: imperative mood (`"Add subtitle menu"` not `"Added..."`)
+- PR title format: `feat: description` or `fix: description`
+
+### Build Configuration
+
+- Webpack configs: `webpack.main.config.js`, `webpack.renderer.config.js`
+- electron-builder config in `package.json` under `build` key
+- Output directory: `release/`
+- Ignore warnings in webpack for known issues (fs-native-extensions)
+
+### Creating Releases
+
+**Automatic (via CI/CD):**
+1. Create and push a version tag:
+   ```bash
+   git tag v1.3.0
+   git push origin v1.3.0
+   ```
+2. GitHub Actions automatically builds and publishes to GitHub Releases
+
+**Manual:**
+1. Build locally: `npm run build && npm run package -- --mac --win --linux`
+2. Create release: `gh release create v1.3.0 --title "Salt Player 1.3.0" --notes "..."`
+3. Upload artifacts: `gh release upload v1.3.0 release/*`
+
+### Additional Notes
+
+- FFmpeg binaries bundled via `ffmpeg-static`, `ffprobe-static`
+- WebTorrent for torrent streaming
+- Fluent-FFmpeg for transcoding
+- Buffer polyfill required for browser polyfills in webpack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Development (runs webpack watchers + electron concurrently)
+npm run dev
+
+# Build only (no packaging)
+npm run build
+
+# Package distributable
+npm run package
+
+# Tests
+npm test                    # watch mode
+npm run test:unit           # run unit tests once
+npm run test:integration    # run integration tests once
+npm run test:coverage       # run with coverage report
+npm run test:watch          # explicit watch mode
+
+# Run a single test file
+npx vitest run tests/unit/torrent.test.ts
+```
+
+TypeScript uses path aliases `@/main/*`, `@/renderer/*`, `@/shared/*` — these are configured in `tsconfig.json` and `vitest.config.ts`.
+
+## Architecture
+
+Salt Player is an Electron app with a strict main/renderer split:
+
+```
+src/
+  main/       — Node.js/Electron main process
+  renderer/   — React UI (browser context, no Node access)
+  shared/     — Types and IPC channel constants shared by both
+```
+
+### Main process
+
+- **`main.ts`** — App entry point. Creates `BrowserWindow`, initializes `StorageManager` and `TorrentEngine`, then calls `setupIPCHandlers`.
+- **`torrent.ts`** — Core engine. Wraps WebTorrent (loaded dynamically because it's an ESM module with top-level await). Spins up a local HTTP server on a random port to stream the selected file, uses ffmpeg/ffprobe (via `ffmpeg-static`/`ffprobe-static`) to probe codecs and transcode when needed (e.g. AC3/DTS audio → AAC). Subtitle tracks are extracted on-demand as WebVTT via ffmpeg and served at `/subtitle/<index>.vtt`. Audio track selection triggers a new transcode URL with `?transcode=true&audioTrack=<index>`. Piece prioritization is done manually to front-load the pieces the player needs.
+- **`ipc-handlers.ts`** — Registers all `ipcMain.handle` listeners; thin delegation layer to `TorrentEngine`.
+- **`preload.ts`** — Exposes `window.electronAPI` to the renderer via `contextBridge`. This is the only safe crossing point between processes.
+- **`storage.ts`** — Creates a per-session temp directory (cleaned on startup and shutdown) for torrent piece storage.
+
+### IPC communication pattern
+
+All IPC channel names are constants in `src/shared/types.ts` (`IPC_CHANNELS`). The main process pushes events to the renderer via `webContents.send` (status updates, video URL, subtitle/audio track data). The renderer invokes main-process operations via `window.electronAPI.*` which calls `ipcRenderer.invoke`.
+
+### Renderer process
+
+- **`App.tsx`** — Root component. Registers all `window.electronAPI` event listeners on mount, orchestrates state for `videoUrl`, `torrentStatus`, `subtitleData`, `audioData`, playlist navigation, etc.
+- **`VideoPlayer.tsx`** — HTML5 `<video>` element with custom controls. Handles subtitle track switching via the `<track>` element API and audio track switching by calling `onSelectAudioTrack` (which goes back to main via IPC, triggering a new transcoded stream URL).
+
+### ffmpeg/transcode flow
+
+1. On file selection, `TorrentEngine.probeStream()` ffprobes the stream URL to detect unsupported audio codecs (AC3, EAC3, DTS, TrueHD, Vorbis).
+2. If unsupported, the video URL sent to the renderer includes `?transcode=true`, causing the HTTP server to pipe the file through an ffmpeg process that transcodes audio to AAC while copying video.
+3. Seeking in transcode mode appends `?startTime=<seconds>` to restart ffmpeg from that offset.
+4. Audio track selection always triggers transcode mode, mapping only the selected audio stream.
+
+### WebTorrent ESM workaround
+
+WebTorrent v2 is an ESM-only package with top-level await. `torrent.ts` loads it with a dynamic `import()` inside an async function and handles multiple possible export shapes (`default`, `.default`, `.WebTorrent`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saltplayer",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saltplayer",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@types/fluent-ffmpeg": "^2.1.28",
@@ -2085,7 +2085,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2692,7 +2691,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2753,7 +2751,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2964,6 +2961,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -2983,6 +2981,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -3004,7 +3003,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -3012,6 +3012,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3027,7 +3028,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3035,6 +3037,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3205,7 +3208,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -3753,7 +3755,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4417,6 +4418,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -4685,6 +4687,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -4724,6 +4727,7 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -5326,7 +5330,6 @@
       "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "builder-util": "24.13.1",
@@ -5628,6 +5631,7 @@
       "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "archiver": "^5.3.1",
@@ -5641,6 +5645,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5656,6 +5661,7 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -5669,6 +5675,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7017,7 +7024,6 @@
       "integrity": "sha512-JzUXOh0wdNGY54oKng5hliuBkq/+aT1V3YpTM+lrN/GoLQTANZsMaIvmHiHe612rauHvPJnDZkZ+5GZR++1Abg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css.escape": "^1.5.1",
         "entities": "^4.5.0",
@@ -8390,6 +8396,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -8402,7 +8409,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -8410,6 +8418,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -8425,7 +8434,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -8433,6 +8443,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -8529,35 +8540,40 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -9765,7 +9781,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10175,7 +10190,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10188,7 +10202,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10242,6 +10255,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -10718,7 +10732,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12131,7 +12144,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12483,7 +12495,6 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",
@@ -12613,7 +12624,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -12663,7 +12673,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -13243,6 +13252,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -13258,6 +13268,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -71,7 +71,16 @@ export function setupIPCHandlers(
     }
   });
 
-  // Open a URL in the OS default handler (e.g. VLC can register as handler, or user can copy/paste)
+  // Select audio track
+  ipcMain.handle(IPC_CHANNELS.AUDIO_SELECT, async (_, streamIndex: number) => {
+    try {
+      await torrentEngine.selectAudioTrack(streamIndex);
+    } catch (error) {
+      console.error('Error selecting audio track:', error);
+      throw error;
+    }
+  });
+
   ipcMain.handle(IPC_CHANNELS.APP_OPEN_EXTERNAL, async (_, url: string) => {
     await shell.openExternal(url);
     return true;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { IPC_CHANNELS, TorrentStatus, TorrentMetadata, ErrorInfo, SubtitleData } from '@/shared/types';
+import { IPC_CHANNELS, TorrentStatus, TorrentMetadata, ErrorInfo, SubtitleData, AudioData } from '@/shared/types';
 
 // Expose safe API to renderer process
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -13,6 +13,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke(IPC_CHANNELS.PLAYBACK_CONTROL, action),
   playbackSeek: (time: number) => 
     ipcRenderer.invoke(IPC_CHANNELS.PLAYBACK_SEEK, time),
+  selectAudioTrack: (streamIndex: number) =>
+    ipcRenderer.invoke(IPC_CHANNELS.AUDIO_SELECT, streamIndex),
   
   // App control
   quit: () => ipcRenderer.invoke(IPC_CHANNELS.APP_QUIT),
@@ -30,6 +32,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   onSubtitles: (callback: (data: SubtitleData) => void) => {
     ipcRenderer.on(IPC_CHANNELS.SUBTITLES, (_, data) => callback(data));
+  },
+  onAudioTracks: (callback: (data: AudioData) => void) => {
+    ipcRenderer.on(IPC_CHANNELS.AUDIO_TRACKS, (_, data) => callback(data));
   },
   onError: (callback: (error: ErrorInfo) => void) => {
     ipcRenderer.on(IPC_CHANNELS.ERROR, (_, error) => callback(error));
@@ -50,12 +55,14 @@ declare global {
       selectFile: (fileName: string) => Promise<void>;
       playbackControl: (action: 'play' | 'pause' | 'stop') => Promise<void>;
       playbackSeek: (time: number) => Promise<void>;
+      selectAudioTrack: (streamIndex: number) => Promise<void>;
       quit: () => Promise<void>;
       openExternal: (url: string) => Promise<boolean>;
       onTorrentStatus: (callback: (status: TorrentStatus) => void) => void;
       onVideoUrl: (callback: (url: string) => void) => void;
       onVideoMetadata: (callback: (metadata: { duration: number }) => void) => void;
       onSubtitles: (callback: (data: SubtitleData) => void) => void;
+      onAudioTracks: (callback: (data: AudioData) => void) => void;
       onError: (callback: (error: ErrorInfo) => void) => void;
       removeAllListeners: (channel: string) => void;
     };

--- a/src/main/torrent.ts
+++ b/src/main/torrent.ts
@@ -1,4 +1,4 @@
-import { TorrentFile, TorrentMetadata, TorrentStatus, IPC_CHANNELS, SubtitleTrack } from '@/shared/types';
+import { TorrentFile, TorrentMetadata, TorrentStatus, IPC_CHANNELS, SubtitleTrack, AudioTrack } from '@/shared/types';
 import { StorageManager } from './storage';
 import { BrowserWindow } from 'electron';
 import * as http from 'http';
@@ -20,8 +20,10 @@ let WebTorrentClass: any = null;
 
 const VIDEO_EXTENSIONS = ['.mp4', '.mkv', '.avi', '.mov', '.webm', '.m4v', '.flv', '.wmv'];
 
+const UNSUPPORTED_AUDIO_CODECS = ['ac3', 'ac-3', 'eac3', 'ec-3', 'dts', 'truehd', 'mlp', 'vorbis'];
+
 /** Extract ISO 639-2 language code from values like "rus-sub", "eng-forced" */
-function normalizeSubtitleLanguage(raw: string): string {
+function normalizeLanguage(raw: string): string {
   const s = (raw || 'und').trim().toLowerCase();
   if (!s || s === 'und') return 'und';
   const match = s.match(/^([a-z]{2,3})(?:[-_].*)?$/);
@@ -38,6 +40,10 @@ export class TorrentEngine {
   private serverPort: number | null = null;
   private statusInterval: NodeJS.Timeout | null = null;
   private subtitleTracks: SubtitleTrack[] = [];
+  private audioTracks: AudioTrack[] = [];
+  private selectedAudioIndex: number | null = null;
+  private currentStreamUrl: string | null = null;
+  private currentFilePathname: string | null = null;
 
   constructor(storageManager: StorageManager) {
     this.storageManager = storageManager;
@@ -270,12 +276,13 @@ export class TorrentEngine {
         }
 
         if (!isResolved) {
+            this.extractAudioTracks(metadata);
+
             let needsTranscode = false;
             const audioStream = metadata.streams.find(s => s.codec_type === 'audio');
             if (audioStream) {
               const codec = audioStream.codec_name?.toLowerCase();
-              const unsupportedCodecs = ['ac3', 'ac-3', 'eac3', 'ec-3', 'dts', 'truehd', 'mlp', 'vorbis']; 
-              if (codec && unsupportedCodecs.includes(codec)) {
+              if (codec && UNSUPPORTED_AUDIO_CODECS.includes(codec)) {
                 console.log(`Transcoding required for codec: ${codec}`);
                 needsTranscode = true;
               }
@@ -321,7 +328,7 @@ export class TorrentEngine {
         subtitleStreams.forEach((stream, index) => {
           const streamAny = stream as { tags?: { language?: string; title?: string; LANGUAGE?: string }; language?: string };
           const rawLang = streamAny.tags?.language ?? streamAny.tags?.LANGUAGE ?? streamAny.language ?? 'und';
-          const lang = normalizeSubtitleLanguage(typeof rawLang === 'string' ? rawLang : 'und');
+          const lang = normalizeLanguage(typeof rawLang === 'string' ? rawLang : 'und');
           const track: SubtitleTrack = {
             index: stream.index,
             language: lang,
@@ -369,10 +376,8 @@ export class TorrentEngine {
         }
 
         if (isTranscode) {
-          // Use the raw HTTP URL as FFmpeg input (not a pipe).
-          // This allows FFmpeg to read MKV headers via HTTP range requests
-          // and seek properly using the container's index.
           const rawFileUrl = `http://127.0.0.1:${this.serverPort}${pathname}`;
+          const audioTrackParam = reqUrl.searchParams.get('audioTrack');
 
           res.writeHead(200, {
             'Content-Type': 'video/x-matroska',
@@ -385,10 +390,22 @@ export class TorrentEngine {
             command.seekInput(startTime);
           }
 
+          if (audioTrackParam) {
+            const audioStreamIndex = parseInt(audioTrackParam, 10);
+            command.outputOptions(['-map 0:v:0', `-map 0:${audioStreamIndex}`]);
+            const track = this.audioTracks.find(t => t.index === audioStreamIndex);
+            const codec = track?.codec?.toLowerCase() ?? '';
+            if (codec && UNSUPPORTED_AUDIO_CODECS.includes(codec)) {
+              command.audioCodec('aac').audioChannels(2);
+            } else {
+              command.audioCodec('copy');
+            }
+          } else {
+            command.audioCodec('aac').audioChannels(2);
+          }
+
           command
             .videoCodec('copy')
-            .audioCodec('aac')
-            .audioChannels(2)
             .format('matroska')
             .on('codecData', (data) => {
               if (data.duration) {
@@ -498,10 +515,13 @@ export class TorrentEngine {
     this.server.listen(0, async () => {
       const address = this.server.address();
       this.serverPort = address?.port ?? null;
+      this.currentFilePathname = pathname;
+      this.selectedAudioIndex = null;
       let streamUrl = `http://127.0.0.1:${this.serverPort}${pathname}`;
 
       console.log(`Streaming server started at ${streamUrl}`);
       const probeResult = await this.probeStream(streamUrl);
+      this.currentStreamUrl = streamUrl;
 
       if (probeResult.duration > 0) {
         this.sendVideoMetadata(probeResult.duration);
@@ -780,6 +800,62 @@ export class TorrentEngine {
     windows.forEach(window => {
       window.webContents.send(IPC_CHANNELS.SUBTITLES, { tracks, hasEmbeddedSubtitles: tracks.length > 0 });
     });
+  }
+
+  private extractAudioTracks(metadata: { streams: any[] }): void {
+    this.audioTracks = [];
+    const audioStreams = metadata.streams.filter((s: any) => s.codec_type === 'audio');
+
+    if (audioStreams.length === 0) {
+      this.sendAudioTracks();
+      return;
+    }
+
+    console.log(`Found ${audioStreams.length} audio track(s)`);
+
+    audioStreams.forEach((stream: any, index: number) => {
+      const rawLang = stream.tags?.language ?? stream.tags?.LANGUAGE ?? stream.language ?? 'und';
+      const lang = normalizeLanguage(typeof rawLang === 'string' ? rawLang : 'und');
+      const track: AudioTrack = {
+        index: stream.index,
+        language: lang,
+        title: stream.tags?.title ?? `Track ${index + 1}`,
+        codec: stream.codec_name ?? 'unknown',
+        channels: stream.channels ?? 2,
+      };
+      this.audioTracks.push(track);
+    });
+
+    this.sendAudioTracks();
+  }
+
+  private sendAudioTracks(): void {
+    const windows = BrowserWindow.getAllWindows();
+    const data = { tracks: this.audioTracks, currentTrackIndex: 0 };
+    windows.forEach(window => {
+      window.webContents.send(IPC_CHANNELS.AUDIO_TRACKS, data);
+    });
+  }
+
+  async selectAudioTrack(streamIndex: number): Promise<void> {
+    if (!this.currentStreamUrl || !this.currentFilePathname) {
+      throw new Error('No active stream');
+    }
+
+    const track = this.audioTracks.find(t => t.index === streamIndex);
+    if (!track) {
+      throw new Error(`Audio track not found: ${streamIndex}`);
+    }
+
+    this.selectedAudioIndex = streamIndex;
+    console.log(`Selecting audio track: ${track.title} (index ${streamIndex}, codec ${track.codec})`);
+
+    const baseUrl = `http://127.0.0.1:${this.serverPort}${this.currentFilePathname}`;
+    const url = new URL(baseUrl);
+    url.searchParams.set('transcode', 'true');
+    url.searchParams.set('audioTrack', String(streamIndex));
+
+    this.sendVideoUrl(url.toString());
   }
 
   /**

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import TorrentInput from './components/TorrentInput';
 import VideoPlayer from './components/VideoPlayer';
 import StatusBar from './components/StatusBar';
-import { TorrentStatus, TorrentMetadata, ErrorInfo, TorrentFile, SubtitleData } from '@/shared/types';
+import { TorrentStatus, TorrentMetadata, ErrorInfo, TorrentFile, SubtitleData, AudioData } from '@/shared/types';
 
 const VIDEO_EXTENSIONS = ['.mp4', '.mkv', '.avi', '.mov', '.webm', '.m4v', '.flv', '.wmv'];
 
@@ -15,12 +15,14 @@ declare global {
       selectFile: (fileName: string) => Promise<void>;
       playbackControl: (action: 'play' | 'pause' | 'stop') => Promise<void>;
       playbackSeek: (time: number) => Promise<void>;
+      selectAudioTrack: (streamIndex: number) => Promise<void>;
       quit: () => Promise<void>;
       openExternal: (url: string) => Promise<boolean>;
       onTorrentStatus: (callback: (status: TorrentStatus) => void) => void;
       onVideoUrl: (callback: (url: string) => void) => void;
       onVideoMetadata: (callback: (metadata: { duration: number }) => void) => void;
       onSubtitles: (callback: (data: SubtitleData) => void) => void;
+      onAudioTracks: (callback: (data: AudioData) => void) => void;
       onError: (callback: (error: ErrorInfo) => void) => void;
       removeAllListeners: (channel: string) => void;
     };
@@ -35,6 +37,7 @@ const App: React.FC = () => {
   const [error, setError] = useState<ErrorInfo | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [subtitleData, setSubtitleData] = useState<SubtitleData | null>(null);
+  const [audioData, setAudioData] = useState<AudioData | null>(null);
 
   useEffect(() => {
     // Set application title
@@ -57,6 +60,11 @@ const App: React.FC = () => {
       console.log('Received subtitles:', data);
       setSubtitleData(data);
     });
+
+    window.electronAPI.onAudioTracks((data) => {
+      console.log('Received audio tracks:', data);
+      setAudioData(data);
+    });
     
     window.electronAPI.onTorrentStatus((status) => {
       setTorrentStatus(status);
@@ -73,6 +81,7 @@ const App: React.FC = () => {
       window.electronAPI.removeAllListeners('video:url');
       window.electronAPI.removeAllListeners('video:metadata');
       window.electronAPI.removeAllListeners('subtitles:available');
+      window.electronAPI.removeAllListeners('audio:available');
       window.electronAPI.removeAllListeners('torrent:status');
       window.electronAPI.removeAllListeners('error');
     };
@@ -103,6 +112,7 @@ const App: React.FC = () => {
       setMetadata(null);
       setIsLoading(false);
       setSubtitleData(null);
+      setAudioData(null);
     } catch (err: any) {
       console.error('Error stopping torrent:', err);
     }
@@ -166,6 +176,14 @@ const App: React.FC = () => {
     }
   };
 
+  const handleSelectAudioTrack = async (streamIndex: number) => {
+    try {
+      await window.electronAPI.selectAudioTrack(streamIndex);
+    } catch (err) {
+      console.error('Error selecting audio track:', err);
+    }
+  };
+
   const handleSelectFile = async (fileName: string) => {
     setIsLoading(true);
     setServerDuration(null);
@@ -195,6 +213,8 @@ const App: React.FC = () => {
         videoFiles={videoFiles}
         onSelectFile={handleSelectFile}
         subtitleData={subtitleData}
+        audioData={audioData}
+        onSelectAudioTrack={handleSelectAudioTrack}
       />
       
       <StatusBar  

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -1,8 +1,7 @@
 import React, { useRef, useState, useEffect, useMemo, useCallback } from 'react';
-import { SubtitleData, SubtitleTrack } from '@/shared/types';
+import { SubtitleData, SubtitleTrack, AudioData, AudioTrack } from '@/shared/types';
 
-// ISO 639-2 language codes → human-readable names (for subtitle menu)
-const SUBTITLE_LANGUAGE_NAMES: Record<string, string> = {
+const LANGUAGE_NAMES: Record<string, string> = {
   eng: 'English', rus: 'Russian', spa: 'Spanish', fra: 'French', deu: 'German',
   ita: 'Italian', por: 'Portuguese', jpn: 'Japanese', kor: 'Korean', zho: 'Chinese',
   ara: 'Arabic', hin: 'Hindi', tur: 'Turkish', pol: 'Polish', ukr: 'Ukrainian',
@@ -27,7 +26,7 @@ function getSubtitleDisplayName(track: SubtitleTrack): string {
     const extracted = t.match(/^([a-z]{2,3})-/i);
     if (extracted) lang = extracted[1].toLowerCase();
   }
-  const langName = SUBTITLE_LANGUAGE_NAMES[lang] || SUBTITLE_LANGUAGE_NAMES[track.language] || 'Unknown';
+  const langName = LANGUAGE_NAMES[lang] || LANGUAGE_NAMES[track.language] || 'Unknown';
   const isGenericTitle = !t || /^Track\s+\d+$/i.test(t) || /^\d+$/.test(t);
   const isTechnicalCode = TECHNICAL_TITLE_PATTERN.test(t);
   const isTechnicalDescriptor = TECHNICAL_TITLES.has(t.toLowerCase());
@@ -36,6 +35,14 @@ function getSubtitleDisplayName(track: SubtitleTrack): string {
     return track.title!;
   }
   return langName;
+}
+
+function getAudioDisplayName(track: AudioTrack): string {
+  const lang = normalizeLanguageForDisplay(track.language);
+  const langName = LANGUAGE_NAMES[lang] || LANGUAGE_NAMES[track.language] || 'Unknown';
+  const codec = (track.codec || '').toUpperCase();
+  const channelLabel = track.channels >= 6 ? '5.1' : track.channels === 1 ? 'Mono' : 'Stereo';
+  return `${langName} (${codec} ${channelLabel})`;
 }
 
 interface VideoPlayerProps {
@@ -50,6 +57,8 @@ interface VideoPlayerProps {
   videoFiles?: { name: string }[];
   onSelectFile?: (fileName: string) => void;
   subtitleData?: SubtitleData | null;
+  audioData?: AudioData | null;
+  onSelectAudioTrack?: (streamIndex: number) => void;
 }
 
 const VideoPlayer: React.FC<VideoPlayerProps> = ({ 
@@ -62,7 +71,9 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   title,
   videoFiles,
   onSelectFile,
-  subtitleData
+  subtitleData,
+  audioData,
+  onSelectAudioTrack,
   }) => {
     const videoRef = useRef<HTMLVideoElement>(null);
     const [isPlaying, setIsPlaying] = useState(false);
@@ -77,7 +88,10 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const [subtitlesEnabled, setSubtitlesEnabled] = useState(false);
   const [currentSubtitleIndex, setCurrentSubtitleIndex] = useState(0);
   const [subtitleMenuOpen, setSubtitleMenuOpen] = useState(false);
+  const [audioMenuOpen, setAudioMenuOpen] = useState(false);
+  const [selectedAudioTrackIndex, setSelectedAudioTrackIndex] = useState(0);
   const subtitleControlRef = useRef<HTMLDivElement>(null);
+  const audioControlRef = useRef<HTMLDivElement>(null);
 
   const isTranscode = useMemo(() => {
     return videoUrl?.includes('transcode=true') || false;
@@ -116,6 +130,24 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [subtitleMenuOpen]);
+
+  useEffect(() => {
+    if (!audioMenuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (audioControlRef.current && !audioControlRef.current.contains(e.target as Node)) {
+        setAudioMenuOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setAudioMenuOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [audioMenuOpen]);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -465,6 +497,39 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                 onChange={handleVolumeChange}
               />
               
+              {audioData && audioData.tracks.length > 1 && onSelectAudioTrack && (
+                <div className="audio-control" ref={audioControlRef}>
+                  <button
+                    type="button"
+                    className="audio-control-btn"
+                    onClick={(e) => { e.stopPropagation(); setAudioMenuOpen((open) => !open); }}
+                    title="Audio track"
+                    aria-expanded={audioMenuOpen}
+                  >
+                    🔊
+                  </button>
+                  {audioMenuOpen && (
+                    <div className="audio-menu" role="menu">
+                      {audioData.tracks.map((track, index) => (
+                        <button
+                          key={track.index}
+                          type="button"
+                          role="menuitem"
+                          className={`audio-menu-item${index === selectedAudioTrackIndex ? ' active' : ''}`}
+                          onClick={() => {
+                            setSelectedAudioTrackIndex(index);
+                            onSelectAudioTrack(track.index);
+                            setAudioMenuOpen(false);
+                          }}
+                        >
+                          {getAudioDisplayName(track)}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
               {subtitleData?.hasEmbeddedSubtitles && (
                 <div className="subtitle-control" ref={subtitleControlRef}>
                   <button

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -399,6 +399,71 @@ body {
   background-color: rgba(255, 255, 255, 0.15);
 }
 
+/* Audio track control */
+.audio-control {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 36px;
+  overflow: visible;
+}
+
+.audio-control-btn {
+  height: 36px;
+  width: 36px;
+  background-color: rgba(255, 255, 255, 0.1);
+  border: none;
+  border-radius: 50%;
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s;
+  padding: 0;
+  font-size: 14px;
+}
+
+.audio-control-btn:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.audio-menu {
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 4px;
+  background-color: rgba(0, 0, 0, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  padding: 4px 0;
+  min-width: 160px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.audio-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 14px;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.audio-menu-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.audio-menu-item.active {
+  background-color: rgba(255, 255, 255, 0.1);
+  font-weight: 600;
+}
+
 .seek-bar {
   flex: 1;
   height: 6px;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -53,6 +53,8 @@ export const IPC_CHANNELS = {
   TORRENT_SELECT_FILE: 'torrent:selectFile',
   VIDEO_METADATA: 'video:metadata',
   SUBTITLES: 'subtitles:available',
+  AUDIO_TRACKS: 'audio:available',
+  AUDIO_SELECT: 'audio:selectTrack',
 } as const;
 
 export type PlaybackControlAction = 'play' | 'pause' | 'stop';
@@ -67,5 +69,18 @@ export interface SubtitleTrack {
 export interface SubtitleData {
   tracks: SubtitleTrack[];
   hasEmbeddedSubtitles: boolean;
+}
+
+export interface AudioTrack {
+  index: number;
+  language: string;
+  title?: string;
+  codec: string;
+  channels: number;
+}
+
+export interface AudioData {
+  tracks: AudioTrack[];
+  currentTrackIndex: number;
 }
 


### PR DESCRIPTION
## Summary

- Adds audio track detection via ffprobe — all audio streams are extracted when a file starts streaming
- New 🔊 button in the player controls bar (only visible when the file has more than one audio track)
- Track names displayed as `Language (CODEC Channels)` — e.g. `Russian (AC3 5.1)`, `English (AAC Stereo)`
- Switching tracks sends an IPC call to the main process, which restarts the ffmpeg transcode pipeline with the selected stream mapped; compatible codecs (AAC, MP3, etc.) are copied, unsupported ones (AC3, DTS, TrueHD, EAC3) are re-encoded to AAC stereo

## Also included

- Fix CI: `test.yml` branch filter updated from `main`/`develop` → `master`
- New `release.yml` workflow for tag-triggered packaging and publishing
- `CLAUDE.md` and `AGENTS.md` developer guides added to repo

## Test plan

- [ ] Open an MKV with multiple audio tracks (e.g. a bilingual rip) — 🔊 button appears
- [ ] Switch between tracks — playback resumes on the new track
- [ ] Open a file with a single audio track — 🔊 button is hidden
- [ ] Switch track on a file with AC3/DTS audio — audio plays correctly (transcoded to AAC)
- [ ] Verify subtitle selection still works after switching audio tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)