### PR TITLE
feat: audio track selection for multi-language video files

### DIFF
--- a/src/main/torrent.ts
+++ b/src/main/torrent.ts
@@ -260,7 +260,7 @@ export class TorrentEngine {
 
       command.ffprobe((err, metadata) => {
         clearTimeout(timeoutId);
-        
+
         if (err) {
           console.error('FFprobe error:', err.message);
           if (!isResolved) {
@@ -268,27 +268,27 @@ export class TorrentEngine {
           }
           return;
         }
-        
+
         const duration = metadata.format?.duration ? Number(metadata.format.duration) : 0;
-        
-        if (isResolved && duration > 0) {
-            this.sendVideoMetadata(duration);
+
+        // Always extract audio tracks when ffprobe succeeds, even after timeout
+        this.extractAudioTracks(metadata);
+
+        if (isResolved) {
+            if (duration > 0) this.sendVideoMetadata(duration);
+            return;
         }
 
-        if (!isResolved) {
-            this.extractAudioTracks(metadata);
-
-            let needsTranscode = false;
-            const audioStream = metadata.streams.find(s => s.codec_type === 'audio');
-            if (audioStream) {
-              const codec = audioStream.codec_name?.toLowerCase();
-              if (codec && UNSUPPORTED_AUDIO_CODECS.includes(codec)) {
-                console.log(`Transcoding required for codec: ${codec}`);
-                needsTranscode = true;
-              }
-            }
-            resolve({ needsTranscode, duration });
+        let needsTranscode = false;
+        const audioStream = metadata.streams.find(s => s.codec_type === 'audio');
+        if (audioStream) {
+          const codec = audioStream.codec_name?.toLowerCase();
+          if (codec && UNSUPPORTED_AUDIO_CODECS.includes(codec)) {
+            console.log(`Transcoding required for codec: ${codec}`);
+            needsTranscode = true;
+          }
         }
+        resolve({ needsTranscode, duration });
       });
     });
   }
@@ -520,6 +520,7 @@ export class TorrentEngine {
       let streamUrl = `http://127.0.0.1:${this.serverPort}${pathname}`;
 
       console.log(`Streaming server started at ${streamUrl}`);
+      this.prioritizeStreamingPieces(file, 0);
       const probeResult = await this.probeStream(streamUrl);
       this.currentStreamUrl = streamUrl;
 
@@ -535,7 +536,6 @@ export class TorrentEngine {
       }
 
       this.sendVideoUrl(streamUrl);
-      this.prioritizeStreamingPieces(file, 0);
     });
   }
 

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -92,13 +92,15 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const [selectedAudioTrackIndex, setSelectedAudioTrackIndex] = useState(0);
   const subtitleControlRef = useRef<HTMLDivElement>(null);
   const audioControlRef = useRef<HTMLDivElement>(null);
+  const pendingAudioSwitchTime = useRef<number | null>(null);
 
   const isTranscode = useMemo(() => {
     return videoUrl?.includes('transcode=true') || false;
   }, [videoUrl]);
 
-  // Reset time offset and subtitle index when video URL changes (new file)
+  // Reset time offset and subtitle index when video URL changes (but not for audio track switches)
   useEffect(() => {
+    if (pendingAudioSwitchTime.current !== null) return;
     setTimeOffset(0);
     setSubtitlesEnabled(false);
     setCurrentSubtitleIndex(0);
@@ -249,15 +251,24 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     if (videoUrl && videoRef.current) {
       const video = videoRef.current;
       setPlaybackError(null);
-      setIsBuffering(true); // Start buffering when URL changes
-      video.src = videoUrl;
+      setIsBuffering(true);
 
-      // Ensure playback isn't muted
+      const resumeTime = pendingAudioSwitchTime.current;
+      pendingAudioSwitchTime.current = null;
+
+      if (resumeTime !== null) {
+        const url = new URL(videoUrl);
+        url.searchParams.set('startTime', Math.floor(resumeTime).toString());
+        setTimeOffset(resumeTime);
+        video.src = url.toString();
+      } else {
+        video.src = videoUrl;
+      }
+
       video.muted = false;
       video.volume = 1;
-      
+
       video.play().catch(err => {
-        // Auto-play might fail
         console.warn('Auto-play failed:', err);
         setIsPlaying(false);
         setIsBuffering(false);
@@ -487,26 +498,28 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                 {formatTime(currentTime)} / {formatTime(duration)}
               </div>
               
-              <input
-                type="range"
-                className="volume-control"
-                min="0"
-                max="1"
-                step="0.1"
-                value={volume}
-                onChange={handleVolumeChange}
-              />
-              
-              {audioData && audioData.tracks.length > 1 && onSelectAudioTrack && (
-                <div className="audio-control" ref={audioControlRef}>
+              {audioData && audioData.tracks.length > 1 && onSelectAudioTrack ? (
+                <div className="volume-group" ref={audioControlRef}>
+                  <div className="volume-slider-pill">
+                    <input
+                      type="range"
+                      className="volume-control"
+                      min="0"
+                      max="1"
+                      step="0.05"
+                      value={volume}
+                      onChange={handleVolumeChange}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </div>
                   <button
                     type="button"
-                    className="audio-control-btn"
+                    className="volume-track-arrow"
                     onClick={(e) => { e.stopPropagation(); setAudioMenuOpen((open) => !open); }}
                     title="Audio track"
                     aria-expanded={audioMenuOpen}
                   >
-                    🔊
+                    ▼
                   </button>
                   {audioMenuOpen && (
                     <div className="audio-menu" role="menu">
@@ -518,6 +531,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                           className={`audio-menu-item${index === selectedAudioTrackIndex ? ' active' : ''}`}
                           onClick={() => {
                             setSelectedAudioTrackIndex(index);
+                            pendingAudioSwitchTime.current = currentTime;
                             onSelectAudioTrack(track.index);
                             setAudioMenuOpen(false);
                           }}
@@ -528,6 +542,16 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
                     </div>
                   )}
                 </div>
+              ) : (
+                <input
+                  type="range"
+                  className="volume-control"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  value={volume}
+                  onChange={handleVolumeChange}
+                />
               )}
 
               {subtitleData?.hasEmbeddedSubtitles && (

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -399,8 +399,8 @@ body {
   background-color: rgba(255, 255, 255, 0.15);
 }
 
-/* Audio track control */
-.audio-control {
+/* Volume + optional audio track selector: [ ══slider══ ][▼] */
+.volume-group {
   position: relative;
   display: flex;
   align-items: center;
@@ -408,23 +408,33 @@ body {
   overflow: visible;
 }
 
-.audio-control-btn {
+.volume-slider-pill {
+  display: flex;
+  align-items: center;
   height: 36px;
-  width: 36px;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 18px 0 0 18px;
+  padding: 0 6px 0 10px;
+}
+
+.volume-track-arrow {
+  height: 36px;
+  width: 20px;
   background-color: rgba(255, 255, 255, 0.1);
   border: none;
-  border-radius: 50%;
+  border-radius: 0 18px 18px 0;
   color: white;
   cursor: pointer;
+  font-size: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: background-color 0.2s;
+  margin-left: -1px;
   padding: 0;
-  font-size: 14px;
 }
 
-.audio-control-btn:hover {
+.volume-track-arrow:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
@@ -481,7 +491,7 @@ body {
 }
 
 .volume-control {
-  width: 100px;
+  width: 80px;
 }
 
 .time-display {

--- a/tests/integration/videoplayer.test.tsx
+++ b/tests/integration/videoplayer.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import VideoPlayer from '@/renderer/components/VideoPlayer';
-import { SubtitleData } from '@/shared/types';
+import { SubtitleData, AudioData } from '@/shared/types';
 
 describe('VideoPlayer Component', () => {
   beforeEach(() => {
@@ -596,6 +596,294 @@ describe('VideoPlayer Component', () => {
       const ccButtonAfter = container.querySelector('.subtitle-control-cc') as HTMLButtonElement;
 
       expect(ccButtonAfter.style.opacity).toBe('0.5');
+    });
+  });
+
+  describe('Audio Track Selection', () => {
+    const mockAudioData: AudioData = {
+      tracks: [
+        { index: 1, language: 'eng', title: 'English', codec: 'aac', channels: 2 },
+        { index: 2, language: 'rus', title: 'Russian', codec: 'ac3', channels: 6 },
+        { index: 3, language: 'deu', title: 'German', codec: 'aac', channels: 2 },
+      ],
+      currentTrackIndex: 0,
+    };
+
+    const singleAudioData: AudioData = {
+      tracks: [
+        { index: 1, language: 'eng', title: 'English', codec: 'aac', channels: 2 },
+      ],
+      currentTrackIndex: 0,
+    };
+
+    it('should always show a volume slider', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+        />
+      );
+
+      const slider = container.querySelector('.volume-control') as HTMLInputElement;
+      expect(slider).toBeTruthy();
+      expect(slider.type).toBe('range');
+    });
+
+    it('should show ▼ button and grouped pill when multiple tracks available', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      expect(container.querySelector('.volume-track-arrow')).toBeTruthy();
+      expect(container.querySelector('.volume-slider-pill')).toBeTruthy();
+    });
+
+    it('should not show ▼ button when audioData is null', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={null}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      expect(container.querySelector('.volume-track-arrow')).toBeFalsy();
+    });
+
+    it('should not show ▼ button when only one audio track', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={singleAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      expect(container.querySelector('.volume-track-arrow')).toBeFalsy();
+    });
+
+    it('should not show ▼ button when onSelectAudioTrack is not provided', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+        />
+      );
+
+      expect(container.querySelector('.volume-track-arrow')).toBeFalsy();
+    });
+
+    it('should open track menu when ▼ is clicked', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      expect(container.querySelector('.audio-menu')).toBeFalsy();
+      fireEvent.click(container.querySelector('.volume-track-arrow') as HTMLButtonElement);
+      expect(container.querySelector('.audio-menu')).toBeTruthy();
+    });
+
+    it('should show all audio tracks in panel with display names', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      fireEvent.click(container.querySelector('.volume-track-arrow') as HTMLButtonElement);
+
+      const items = container.querySelectorAll('.audio-menu-item');
+      expect(items).toHaveLength(3);
+      expect(items[0].textContent).toBe('English (AAC Stereo)');
+      expect(items[1].textContent).toBe('Russian (AC3 5.1)');
+      expect(items[2].textContent).toBe('German (AAC Stereo)');
+    });
+
+    it('should call onSelectAudioTrack with correct stream index when track is selected', () => {
+      const onSelectAudioTrack = vi.fn();
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={onSelectAudioTrack}
+        />
+      );
+
+      fireEvent.click(container.querySelector('.volume-track-arrow') as HTMLButtonElement);
+      const items = container.querySelectorAll('.audio-menu-item');
+      fireEvent.click(items[1]); // Russian track, stream index 2
+
+      expect(onSelectAudioTrack).toHaveBeenCalledWith(2);
+    });
+
+    it('should close panel after selecting a track', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      fireEvent.click(container.querySelector('.volume-track-arrow') as HTMLButtonElement);
+      expect(container.querySelector('.audio-menu')).toBeTruthy();
+
+      fireEvent.click(container.querySelectorAll('.audio-menu-item')[0]);
+      expect(container.querySelector('.audio-menu')).toBeFalsy();
+    });
+
+    it('should mark selected track as active', () => {
+      const { container } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      fireEvent.click(container.querySelector('.volume-track-arrow') as HTMLButtonElement);
+      fireEvent.click(container.querySelectorAll('.audio-menu-item')[1]); // select Russian
+
+      fireEvent.click(container.querySelector('.volume-track-arrow') as HTMLButtonElement);
+      const items = container.querySelectorAll('.audio-menu-item');
+      expect(items[1].classList.contains('active')).toBe(true);
+      expect(items[0].classList.contains('active')).toBe(false);
+    });
+
+    it('should resume playback from current position when audio track changes', () => {
+      const { container, rerender } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv?transcode=true"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      const video = container.querySelector('video') as HTMLVideoElement;
+
+      // Simulate video playing at 120 seconds
+      Object.defineProperty(video, 'currentTime', { value: 120, writable: true, configurable: true });
+      fireEvent(video, new Event('timeupdate'));
+
+      // Select audio track
+      fireEvent.click(container.querySelector('.volume-track-arrow') as HTMLButtonElement);
+      fireEvent.click(container.querySelectorAll('.audio-menu-item')[1]);
+
+      // Simulate new URL arriving from main process (after IPC call)
+      rerender(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv?transcode=true&audioTrack=2"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      expect(video.src).toContain('startTime=120');
+    });
+
+    it('should not add startTime when URL changes for non-audio reasons', () => {
+      const { container, rerender } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/episode1.mkv"
+          title="Episode 1"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      const video = container.querySelector('video') as HTMLVideoElement;
+      Object.defineProperty(video, 'currentTime', { value: 60, writable: true, configurable: true });
+      fireEvent(video, new Event('timeupdate'));
+
+      // URL changes due to episode switch (no audio track selection)
+      rerender(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/episode2.mkv"
+          title="Episode 2"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+        />
+      );
+
+      expect(video.src).not.toContain('startTime');
+    });
+
+    it('should not reset subtitles when audio track changes', () => {
+      const mockSubtitleData: SubtitleData = {
+        tracks: [
+          { index: 0, language: 'eng', title: 'English', url: 'http://localhost:8080/subtitle/0.vtt' },
+        ],
+        hasEmbeddedSubtitles: true,
+      };
+
+      const { container, rerender } = render(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv?transcode=true"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      // Enable subtitles
+      fireEvent.click(container.querySelector('.subtitle-control-cc') as HTMLButtonElement);
+      expect((container.querySelector('.subtitle-control-cc') as HTMLButtonElement).style.opacity).toBe('1');
+
+      // Select audio track
+      fireEvent.click(container.querySelector('.volume-track-arrow') as HTMLButtonElement);
+      fireEvent.click(container.querySelectorAll('.audio-menu-item')[1]);
+
+      // New URL arrives
+      rerender(
+        <VideoPlayer
+          videoUrl="http://localhost:8080/video.mkv?transcode=true&audioTrack=2"
+          title="Test"
+          onClose={vi.fn()}
+          audioData={mockAudioData}
+          onSelectAudioTrack={vi.fn()}
+          subtitleData={mockSubtitleData}
+        />
+      );
+
+      // Subtitles should still be enabled
+      expect((container.querySelector('.subtitle-control-cc') as HTMLButtonElement).style.opacity).toBe('1');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds audio track selection for MKV and other multi-audio files — volume slider gains a ▼ button that opens a track list, visually grouped as a single control (consistent with CC subtitle button)
- Fixes ffprobe race condition: file pieces are now prioritised before probing, so MKV headers are available quickly; audio tracks are always extracted when ffprobe succeeds, even if the 10s timeout already fired
- Resuming playback from the current position when switching audio tracks instead of restarting from the beginning

## Test plan

- [ ] Load a multi-language torrent (e.g. MKV with Russian + English audio) and verify the ▼ button appears next to the volume slider
- [ ] Switch audio track and verify playback resumes from the same position
- [ ] Verify subtitles are not reset when switching audio tracks
- [ ] Verify volume slider still works normally
- [ ] Single-audio files: ▼ button should not appear
- [ ] `npm run test:integration` — all 75 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)